### PR TITLE
Run script changes

### DIFF
--- a/run/run-fft.sh
+++ b/run/run-fft.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #defaults
 
-DEF_INPUTS=$((32*1024*1024))
+DEF_INPUTS=134217728 # Medium
 
 #don't modify from here
 

--- a/run/run-fib.sh
+++ b/run/run-fib.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 #defaults
 
-DEF_INPUTS=20
+DEF_INPUTS=50   # Medium
+DEF_CUTOFFS=10  # Medium
 
 #don't modify from here
 

--- a/run/run-floorplan.sh
+++ b/run/run-floorplan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #defaults
 
-DEF_INPUTS=input.20
+DEF_INPUTS=input.20 # Medium
 
 #don't modify from here
 

--- a/run/run-knapsack.sh
+++ b/run/run-knapsack.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #defaults
 
-DEF_INPUTS=knapsack-036.input
+DEF_INPUTS=knapsack-040.input # Medium
 
 #don't modify from here
 

--- a/run/run-nqueens.sh
+++ b/run/run-nqueens.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 #defaults
 
-DEF_INPUTS=14
+DEF_INPUTS=14   # Medium
+DEF_CUTOFFS=8   # Medium
 
 #don't modify from here
 

--- a/run/run-sort.sh
+++ b/run/run-sort.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #defaults
 
-DEF_INPUTS=$((32*1024*1024))
+DEF_INPUTS=134217728 # Medium
 
 #don't modify from here
 

--- a/run/run-sparselu.sh
+++ b/run/run-sparselu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #defaults
 
-DEF_INPUTS=25x25
+DEF_INPUTS=75x100 # Medium
 
 #don't modify from here
 

--- a/run/run-strassen.sh
+++ b/run/run-strassen.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #defaults
 
-DEF_INPUTS=1024
+DEF_INPUTS=8192 # Medium
 
 #don't modify from here
 

--- a/run/run-uts.sh
+++ b/run/run-uts.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 #defaults
 
-DEF_INPUTS=medium.input
+DEF_INPUTS=medium.input     # Medium
+export OMP_STACKSIZE="55M"  # Necessary to avoid segfault
 
 #don't modify from here
 

--- a/run/run.common
+++ b/run/run.common
@@ -1,7 +1,9 @@
 DEF_CPUS=all
 DEF_VERSIONS=all
 DEF_LABELS=all
-DEF_CUTOFFS=none
+if [ -z "$DEF_CUTOFFS" ]; then
+    DEF_CUTOFFS=none
+fi
 
 print_help()
 {


### PR DESCRIPTION
- Default values are now consistent: They are medium.
- Individual run-scripts can now specify DEF_CUTOFFS, and run.common
    will respect it.
- The run-script for uts now exports OMP_STACKSIZE to avoid segfault